### PR TITLE
Add Travis-CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: cpp
+
+compiler:
+  - gcc
+  - clang
+
+before_script:
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get update -qq
+  - if [ "$CXX" = "clang++" ]; then sudo apt-get install -qq libstdc++-4.8-dev; fi
+  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  - mkdir /tmp/lld
+  - mv * /tmp/lld
+  - git clone --depth=1 https://github.com/avr-llvm/llvm llvm
+  - mv /tmp/lld llvm/tools/
+  - cd llvm/
+


### PR DESCRIPTION
Tested. It's a bit annoying that we rely on LLVM to build lld.

Any thoughts on a way we could build lld outside of the LLVM source tree? Maybe we can have a pre-built tar ball or something?
